### PR TITLE
Adding Travis CI automated building.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,9 @@ compiler:
  
 install:
 - sudo apt-get -y install autoconf build-essential pkg-config libboost-dev libgmp3-dev libxml2-dev liblua5.1-0-dev libmysqlclient-dev libcrypto++-dev ccache libboost-filesystem-dev libboost-regex-dev libboost-system-dev libboost-thread-dev libssl-dev lua5.1 liblua5.1-sql-mysql-dev libncurses5-dev
-#- wget http://www.lua.org/ftp/lua-5.1.4.tar.gz
-#- tar -xzvf lua* && cd lua*
-#- sudo make linux
-#- sudo make install
 - cd $TRAVIS_BUILD_DIR/source
 
 script: 
 - autoreconf -vfi --warnings=none
 - ./configure --enable-mysql --enable-server-diag
-- echo "8 cores"
-- make -j 9
+- make 


### PR DESCRIPTION
Travis CI will build the source every time there is a commit(including pull requests.), this will let you see if you have any problems with your code.

All you must do is enable Travis CI from your Github account and enable this repo from the Travis CI options.

Build logs look like this: https://travis-ci.org/dominique120/OTHire/builds/21848901
