### PR TITLE
Show loot on channel when killing monsters

### DIFF
--- a/data/creaturescripts/creaturescripts.xml
+++ b/data/creaturescripts/creaturescripts.xml
@@ -8,4 +8,5 @@
 	<event name="ServerRecord" type="login" script="record.lua"/>
 	<event type="login" name="giveFirstItems" script="firstitems.lua" />
 	<!--event name="PlayerLook" type="look" script="look.lua"/-->
+	<event name="loot" type="kill" script="loot.lua"/>
 </creaturescripts>

--- a/data/creaturescripts/scripts/loot.lua
+++ b/data/creaturescripts/scripts/loot.lua
@@ -1,0 +1,46 @@
+function getContentDescription(uid, comma)
+local ret, i, containers = '', 0, {}
+while i < getContainerSize(uid) do
+	local v, s = getContainerItem(uid, i), ''
+	local k = getItemDescriptions(v.itemid)
+if k.name ~= '' then
+	if v.type > 1 and k.stackable and k.showCount then
+		s = v.type .. ' ' .. getItemDescriptions(v.itemid).plural
+		else
+		local article = k.article
+		s = (article == '' and '' or article .. ' ') .. k.name
+	end
+	ret = ret .. (i == 0 and not comma and '' or ', ') .. s
+	if isContainer(v.uid) and getContainerSize(v.uid) > 0 then
+		
+	end
+	else
+		ret = ret .. (i == 0 and not comma and '' or ', ') .. 'an item of type ' .. v.itemid .. ', please report it to gamemaster'
+	end
+	i = i + 1
+	end
+	for i = 1, #containers do
+		ret = ret .. getContentDescription(containers[i], true)
+	end
+return ret
+end
+
+local function send(cid, pos, name, party)
+local corpse = getTileItemByType(pos, ITEM_TYPE_CONTAINER).uid
+local ret = isContainer(corpse) and getContentDescription(corpse)
+doPlayerSendTextMessage(cid, MESSAGE_INFO_DESCR, 'Loot of ' .. name .. ': ' .. (ret ~= '' and ret or 'nothing'))
+if party then
+	for _, pid in ipairs(getPartyMembers(cid)) do
+	--doPlayerSendChannelMessage(pid, '', 'Loot of ' .. name .. ': ' .. (ret ~= '' and ret or 'nothing'), TALKTYPE_CHANNEL_W, CHANNEL_PARTY)
+  --not working in OTHire, Fix pending, using workaround below
+  doPlayerSendTextMessage(pid, MESSAGE_INFO_DESCR, 'Loot of ' .. name .. ': ' .. (ret ~= '' and ret or 'nothing'))
+end
+end
+end
+
+function onKill(cid, target, lastHit)
+if not isPlayer(target) then
+	addEvent(send, 0, cid, getThingPos(target), getCreatureName(target), getPartyMembers(cid))
+end
+return true
+end

--- a/source/luascript.cpp
+++ b/source/luascript.cpp
@@ -7836,6 +7836,8 @@ int LuaScriptInterface::luaGetItemDescriptions(lua_State *L)
 	setField(L, "name", it.name.c_str());
 	setField(L, "article", it.article.c_str());
 	setField(L, "plural", it.pluralName.c_str());
+	setField(L, "stackable", it.stackable);
+	setField(L, "showCount", it.showCount);
 	return 1;
 }
 


### PR DESCRIPTION

![loot](https://cloud.githubusercontent.com/assets/7066891/18276037/a4ed2c64-7449-11e6-98a2-0c2420a70118.png)
Minor fixes to source and creaturescripts to show loot on channel.
Pending fix for party members, but with the workaround is working ok atm