### PR TITLE
Minor fix on Guild System

### DIFF
--- a/source/guild.cpp
+++ b/source/guild.cpp
@@ -78,6 +78,7 @@ bool Guilds::getGuildIdByName(uint32_t& guildId, const std::string& guildName)
 		guild->setId(result->getDataInt("id"));
 		guild->setName(result->getDataString("name"));
 		loadedGuilds[guild->getId()] = guild;
+		guildId = guild->getId();
 		db->freeResult(result);
 		return true;
 	}


### PR DESCRIPTION
When you use ```getGuildIdByName``` for the first time and if the guild is not in the array, the method will return an incorrect value...