### PR TITLE
Fix payRent on house.cpp

### DIFF
--- a/source/house.cpp
+++ b/source/house.cpp
@@ -952,7 +952,10 @@ bool Houses::payRent(Player* player, House* house, time_t time /*= 0*/)
 		default:
 			break;
 		}
-
+		
+		house->setLastWarning(0);
+		house->setPayRentWarnings(0);
+		
 		house->setPaidUntil(paidUntil);
 	}
 


### PR DESCRIPTION
When you have warnings and finally pay the rent it didn't reset warnings.