### PR TITLE
Add a Docker support to allow a quick way to compile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest
+
+COPY . /otserv/.
+
+RUN echo http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    apk update && \
+    apk upgrade && \
+    apk add --no-cache autoconf build-base pkgconfig boost-dev gmp-dev libxml2-dev && \
+    apk add --no-cache automake lua lua-dev mariadb-dev crypto++ ccache
+    cd /otserv/source && \
+    chmod +x autogen.sh && \
+    ./autogen.sh && \
+    ./configure --enable-mysql --enable-server-diag && \
+    make

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ It is a fork of the [OpenTibia Server](https://github.com/opentibia/server) proj
 * MySql_Schema.sql default `account // password` is `123456 // tibia`.
 * For more information check our [Wiki](https://github.com/TwistedScorpio/OTHire/wiki).
 
+#### Using Docker
+
+If you want, you can use Docker to compile it.
+
+```
+$ docker-compose build
+```
+
+It will start a Alpine container, install dependencies and compile the current code from `source/` into the container. Works on any machine with Docker installed.
+
 ### Issues and Support
 
 If you need help, please visit [our OTLand forum thread](https://otland.net/threads/7-72-othire-0-0-3.246964/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  otserv:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "7171:7171"


### PR DESCRIPTION
This makes a compilation process easy by just one single command. Just requires some knowledge on how it works. But basically it runs a Linux container from a image, download dependencies and compile whatever you have into `source/` (as far as instructions go) independent of the platform you're running. The only required software is Docker.

I think it's good to speed up new developers arrivals and to give yet another resource on compiling.