### PR TITLE
Party Self-Invite Crash Fix

### DIFF
--- a/source/game.cpp
+++ b/source/game.cpp
@@ -3159,6 +3159,9 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 	if(!invitedPlayer || invitedPlayer->isRemoved() || invitedPlayer->isInviting(player)){
 		return false;
 	}
+	
+	if(playerId == inviteId)
+		return;
 
 	if(invitedPlayer->getParty()){
 		std::stringstream ss;

--- a/source/game.cpp
+++ b/source/game.cpp
@@ -3160,8 +3160,8 @@ bool Game::playerInviteToParty(uint32_t playerId, uint32_t invitedId)
 		return false;
 	}
 	
-	if(playerId == inviteId)
-		return;
+	if(playerId == invitedId)
+		return false;
 
 	if(invitedPlayer->getParty()){
 		std::stringstream ss;


### PR DESCRIPTION
This will fix the self-inviting party crash. You can invite yourself to a party via OTClient terminal.