### PR TITLE
Loot channel first part

### DIFF
--- a/data/creaturescripts/scripts/lootmessage.lua
+++ b/data/creaturescripts/scripts/lootmessage.lua
@@ -60,7 +60,9 @@ local function send(cid, lastHit, pos, name, party, target)
 			for _, pid in ipairs(getPartyMembers(cid)) do
 				local send = getPlayerStorageValue(pid,STORAGE_LOOTMESSAGE)
 				if send == 1 then
-					doPlayerSendTextMessage(pid, MESSAGE_INFO_DESCR, 'Loot of '.. getArticleByWord(name) .. ' ' .. string.lower(name) .. ': ' .. (ret ~= '' and ret or 'nothing'))
+					local message = 'Loot of '.. getArticleByWord(name) .. ' ' .. string.lower(name) .. ': ' .. (ret ~= '' and ret or 'nothing')
+					sendLootChannelMessage(pid, message)
+					doPlayerSendTextMessage(pid, MESSAGE_INFO_DESCR, message)
 				end
 			end
 			MessageSent[hash] = true
@@ -69,7 +71,10 @@ local function send(cid, lastHit, pos, name, party, target)
 	else
 		local send = getPlayerStorageValue(cid,STORAGE_LOOTMESSAGE)
 		if send == 1 then
-			doPlayerSendTextMessage(cid, MESSAGE_INFO_DESCR, 'Loot of '.. getArticleByWord(name) .. ' ' .. string.lower(name) .. ': ' .. (ret ~= '' and ret or 'nothing'))
+			local message = 'Loot of '.. getArticleByWord(name) .. ' ' .. string.lower(name) .. ': ' .. (ret ~= '' and ret or 'nothing')
+			sendLootChannelMessage(cid, message)
+			doPlayerSendTextMessage(cid, MESSAGE_INFO_DESCR, message)
+
 		end
 	end
 	

--- a/source/chat.cpp
+++ b/source/chat.cpp
@@ -147,6 +147,10 @@ bool ChatChannel::talk(Player* fromPlayer, SpeakClasses type, const std::string&
 	if(iter == m_users.end())
 		return false;
 
+	//can't talk in loot channel
+	if (getId() == CHANNEL_LOOT)
+		return true;
+
 	// Add trade muted condition
 	if(getId() == CHANNEL_TRADE){
 		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_TRADE_MUTED, 120000, 0);
@@ -197,6 +201,10 @@ Chat::Chat()
 	newChannel = new ChatChannel(CHANNEL_HELP, "Help");
 	if(newChannel)
 		m_normalChannels[CHANNEL_HELP] = newChannel;
+
+	newChannel = new ChatChannel(CHANNEL_LOOT, "Loot Channel");
+	if(newChannel)
+		m_normalChannels[CHANNEL_LOOT] = newChannel;
 
 	newChannel = new PrivateChatChannel(CHANNEL_PRIVATE, "Private Chat Channel");
 	if(newChannel)

--- a/source/chat.h
+++ b/source/chat.h
@@ -40,6 +40,7 @@ enum ChannelID {
 	CHANNEL_TRADE      = 0x05,
 	CHANNEL_RL_CHAT    = 0x06,
 	CHANNEL_HELP       = 0x07,
+	CHANNEL_LOOT       = 0x08,
 	CHANNEL_PRIVATE    = 0xFFFF
 };
 

--- a/source/luascript.cpp
+++ b/source/luascript.cpp
@@ -41,6 +41,7 @@
 #include "movement.h"
 #include "tools.h"
 #include "guild.h"
+#include "chat.h"
 #include <string>
 #include <iostream>
 #include <sstream>
@@ -52,6 +53,7 @@ extern ConfigManager g_config;
 extern MoveEvents* g_moveEvents;
 extern Spells* g_spells;
 extern Guilds g_guilds;
+extern Chat g_chat;
 
 enum{
 	EVENT_ID_LOADING = 1,
@@ -1876,6 +1878,9 @@ void LuaScriptInterface::registerFunctions()
 
 	//sendPartyChannelMessage(cid, message)
 	lua_register(m_luaState, "sendPartyChannelMessage", LuaScriptInterface::luaSendPartyChannelMessage);
+
+	//sendLootChannelMessage(cid, message)
+	lua_register(m_luaState, "sendLootChannelMessage", LuaScriptInterface::luaSendLootChannelMessage);
 
 	//canUseSharedExperience(cid)
 	lua_register(m_luaState, "canUseSharedExperience", LuaScriptInterface::luaCanUseSharedExperience);
@@ -8476,6 +8481,28 @@ int LuaScriptInterface::luaSendPartyChannelMessage(lua_State *L)
 		if(Party* party = player->getParty())
 		{
 			lua_pushboolean(L, party->sendChannelMessage(player, SPEAK_CHANNEL_O, message));
+			return 1;
+		}
+	}
+
+	lua_pushboolean(L, false);
+	return 1;
+}
+
+int LuaScriptInterface::luaSendLootChannelMessage(lua_State *L)
+{
+	//sendLootChannelMessage(cid, message)
+	std::string message = popString(L);
+	uint32_t cid = popNumber(L);
+
+	ScriptEnviroment* env = getScriptEnv();
+	if(Player* player = env->getPlayerByUID(cid))
+	{
+		ChatChannel* channel = g_chat.getChannel(player, CHANNEL_LOOT);
+
+		if(channel)
+		{
+			lua_pushboolean(L, channel->sendInfo(SPEAK_CHANNEL_O, message));
 			return 1;
 		}
 	}

--- a/source/luascript.h
+++ b/source/luascript.h
@@ -632,6 +632,8 @@ protected:
 	static int luaSendPartyChannelMessage(lua_State* L);
 	static int luaCanUseSharedExperience(lua_State* L);
 
+	static int luaSendLootChannelMessage(lua_State* L);
+
 	static int luaHasCondition(lua_State *L);
 
 	static int luaIsCreatureImmuneToCondition(lua_State *L);


### PR DESCRIPTION
This is a simple loot channel, it sends all loot messages to that channel

To fix: send messages only if player has opened that channel

 