### PR TITLE
Creatureevent onLogout called with every Player::onThink call

### DIFF
--- a/source/player.cpp
+++ b/source/player.cpp
@@ -1978,7 +1978,7 @@ void Player::onThink(uint32_t interval)
 		}
 	}
 
-	if(canLogout() && !hasCondition(CONDITION_INFIGHT) && !client){
+	if(!hasCondition(CONDITION_INFIGHT) && !client && canLogout()){
 		g_game.removeCreature(this, true);
 	}
 


### PR DESCRIPTION
There is a bug.
Player::canLogout calls "g_creatureEvents->playerLogOut(this)", so every onLogout event is called and I believe it is unwanted behaviour. The solution is simple. Just change the order of elements in condition.